### PR TITLE
fix: add SDK license metadata

### DIFF
--- a/api/go/LICENSE
+++ b/api/go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Unkey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api/py/.speakeasy/gen.yaml
+++ b/api/py/.speakeasy/gen.yaml
@@ -67,7 +67,7 @@ python:
   inferUnionDiscriminators: true
   inputModelSuffix: input
   legacyPyright: false
-  license: ""
+  license: MIT
   maxMethodParams: 0
   methodArguments: infer-optional-args
   moduleName: unkey.py

--- a/api/py/LICENSE
+++ b/api/py/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Unkey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api/py/pyproject.toml
+++ b/api/py/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "jsonpath-python >=1.0.6",
     "pydantic >=2.11.2",
 ]
+license = { text = "MIT" }
 
 [tool.poetry]
 repository = "https://github.com/unkeyed/sdks.git"

--- a/api/ts/gen.yaml
+++ b/api/ts/gen.yaml
@@ -36,7 +36,8 @@ typescript:
     devDependencies:
       '@types/node': ^22
     peerDependencies: {}
-  additionalPackageJSON: {}
+  additionalPackageJSON:
+    license: MIT
   additionalScripts: {}
   alwaysIncludeInboundAndOutbound: false
   author: Speakeasy

--- a/api/ts/package-lock.json
+++ b/api/ts/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@unkey/api",
       "version": "2.3.5",
+      "license": "MIT",
       "dependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       },

--- a/api/ts/package.json
+++ b/api/ts/package.json
@@ -2,6 +2,7 @@
   "name": "@unkey/api",
   "version": "2.3.5",
   "author": "Speakeasy",
+  "license": "MIT",
   "type": "module",
   "tshy": {
     "sourceDialects": [


### PR DESCRIPTION
## Summary
- add MIT license metadata to the generated TypeScript npm package output
- add MIT license metadata to the generated Python package config/output
- add module-level MIT LICENSE files for the Go and Python SDK packages

## Verification
- node metadata check for api/ts package.json and package-lock.json
- python3 TOML parse for api/py/pyproject.toml