### PR TITLE
fix(go): enable nullable request wrappers

### DIFF
--- a/api/go/gen.yaml
+++ b/api/go/gen.yaml
@@ -56,7 +56,7 @@ go:
   methodArguments: require-security-and-request
   modulePath: github.com/unkeyed/sdks/api/go
   multipartArrayFormat: legacy
-  nullableOptionalWrapper: false
+  nullableOptionalWrapper: true
   outputModelSuffix: output
   respectRequiredFields: false
   respectTitlesForPrimitiveUnionMembers: false


### PR DESCRIPTION
## Problem:

Optional nullable Go request fields cannot distinguish an omitted value from explicit JSON `null` with the current generator configuration.

## Solution:

Enable Speakeasy’s built-in `nullableOptionalWrapper` generation option for the Go SDK.

## Impact:

The next Go SDK regeneration will represent optional nullable request fields with a three-state wrapper. This config-only change does not modify generated SDK code.

## Testing:

- `git diff --check`
- Confirmed the PR changes only `api/go/gen.yaml`