### PR TITLE
test(go): make identity serialization test version neutral

### DIFF
--- a/api/go/models/components/identity_update_test.go
+++ b/api/go/models/components/identity_update_test.go
@@ -1,48 +1,29 @@
-package v2_test
+package components
 
 import (
-	"context"
 	"encoding/json"
-	"io"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	unkey "github.com/unkeyed/sdks/api/go/v2"
-	"github.com/unkeyed/sdks/api/go/v2/models/components"
 )
 
 func TestUpdateIdentityRequestSerialization(t *testing.T) {
-	wireBody := make(chan []byte, 1)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-		body, err := io.ReadAll(request.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		wireBody <- body
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	t.Cleanup(server.Close)
-
-	client := unkey.New(unkey.WithSecurity("unkey_dummy"), unkey.WithServerURL(server.URL))
-	rateLimit := components.RatelimitRequest{
+	autoApply := true
+	rateLimit := RatelimitRequest{
 		Name:      "requests",
 		Limit:     1000,
 		Duration:  3_600_000,
-		AutoApply: unkey.Bool(true),
+		AutoApply: &autoApply,
 	}
 
 	tests := []struct {
 		name     string
-		request  components.V2IdentitiesUpdateIdentityRequestBody
+		request  V2IdentitiesUpdateIdentityRequestBody
 		expected map[string]any
 	}{
 		{
 			name: "omits nil metadata and rate limits",
-			request: components.V2IdentitiesUpdateIdentityRequestBody{
+			request: V2IdentitiesUpdateIdentityRequestBody{
 				Identity:   "user_123",
 				Meta:       nil,
 				Ratelimits: nil,
@@ -51,7 +32,7 @@ func TestUpdateIdentityRequestSerialization(t *testing.T) {
 		},
 		{
 			name: "includes empty metadata to clear it",
-			request: components.V2IdentitiesUpdateIdentityRequestBody{
+			request: V2IdentitiesUpdateIdentityRequestBody{
 				Identity: "user_123",
 				Meta:     map[string]any{},
 			},
@@ -59,7 +40,7 @@ func TestUpdateIdentityRequestSerialization(t *testing.T) {
 		},
 		{
 			name: "includes populated metadata",
-			request: components.V2IdentitiesUpdateIdentityRequestBody{
+			request: V2IdentitiesUpdateIdentityRequestBody{
 				Identity: "user_123",
 				Meta: map[string]any{
 					"enabled": true,
@@ -78,17 +59,17 @@ func TestUpdateIdentityRequestSerialization(t *testing.T) {
 		},
 		{
 			name: "includes empty rate limits to clear them",
-			request: components.V2IdentitiesUpdateIdentityRequestBody{
+			request: V2IdentitiesUpdateIdentityRequestBody{
 				Identity:   "user_123",
-				Ratelimits: []components.RatelimitRequest{},
+				Ratelimits: []RatelimitRequest{},
 			},
 			expected: map[string]any{"identity": "user_123", "ratelimits": []any{}},
 		},
 		{
 			name: "includes populated rate limits",
-			request: components.V2IdentitiesUpdateIdentityRequestBody{
+			request: V2IdentitiesUpdateIdentityRequestBody{
 				Identity:   "user_123",
-				Ratelimits: []components.RatelimitRequest{rateLimit},
+				Ratelimits: []RatelimitRequest{rateLimit},
 			},
 			expected: map[string]any{
 				"identity": "user_123",
@@ -99,10 +80,10 @@ func TestUpdateIdentityRequestSerialization(t *testing.T) {
 		},
 		{
 			name: "includes empty metadata with populated rate limits",
-			request: components.V2IdentitiesUpdateIdentityRequestBody{
+			request: V2IdentitiesUpdateIdentityRequestBody{
 				Identity:   "user_123",
 				Meta:       map[string]any{},
-				Ratelimits: []components.RatelimitRequest{rateLimit},
+				Ratelimits: []RatelimitRequest{rateLimit},
 			},
 			expected: map[string]any{
 				"identity": "user_123",
@@ -114,12 +95,12 @@ func TestUpdateIdentityRequestSerialization(t *testing.T) {
 		},
 		{
 			name: "includes populated metadata with empty rate limits",
-			request: components.V2IdentitiesUpdateIdentityRequestBody{
+			request: V2IdentitiesUpdateIdentityRequestBody{
 				Identity: "user_123",
 				Meta: map[string]any{
 					"plan": "pro",
 				},
-				Ratelimits: []components.RatelimitRequest{},
+				Ratelimits: []RatelimitRequest{},
 			},
 			expected: map[string]any{
 				"identity":   "user_123",
@@ -129,10 +110,10 @@ func TestUpdateIdentityRequestSerialization(t *testing.T) {
 		},
 		{
 			name: "includes empty metadata and rate limits",
-			request: components.V2IdentitiesUpdateIdentityRequestBody{
+			request: V2IdentitiesUpdateIdentityRequestBody{
 				Identity:   "user_123",
 				Meta:       map[string]any{},
-				Ratelimits: []components.RatelimitRequest{},
+				Ratelimits: []RatelimitRequest{},
 			},
 			expected: map[string]any{
 				"identity":   "user_123",
@@ -144,11 +125,12 @@ func TestUpdateIdentityRequestSerialization(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			expectedBody, err := json.Marshal(test.expected)
+			actualBody, err := json.Marshal(test.request)
 			require.NoError(t, err)
 
-			_, _ = client.Identities.UpdateIdentity(context.Background(), test.request)
-			require.JSONEq(t, string(expectedBody), string(<-wireBody))
+			expectedBody, err := json.Marshal(test.expected)
+			require.NoError(t, err)
+			require.JSONEq(t, string(expectedBody), string(actualBody))
 		})
 	}
 }


### PR DESCRIPTION
## Problem:

The identity serialization test used the versioned root package and `/v2` imports. Speakeasy changes generated files to package `v3` before compilation, so this test blocked Go SDK v3 generation.

## Solution:

Move the serialization test to the stable `models/components` package. Keep the same JSON serialization coverage without versioned package imports.

## Impact:

Go SDK major-version generation can compile without deleting or disabling the test. SDK runtime behavior does not change.

## Testing:

- Current v2: `go test -count=1 ./...`
- Speakeasy generation: `speakeasy run -t api-go --set-version 3.0.0 --skip-testing --skip-upload-spec --minimal -y -o console`
- Generated v3: `go test -count=1 ./...`

All checks passed.